### PR TITLE
feat: add Casper network support to the exact scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ x402 v2 treats the payment **scheme** (the on-chain protocol used to move
 funds) and the **network** (which chain that protocol runs on) as two
 independent axes. This facilitator currently supports:
 
-| Scheme  | `eip155:*` (EVM) | `solana:*` | `sui:*` | `tron:*` |
-|---------|:----------------:|:----------:|:-------:|:--------:|
-| `exact` |        ✅        |     🚧     |   🚧    |    🚧    |
+| Scheme  | `eip155:*` (EVM) | `solana:*` | `sui:*` | `tron:*` | `casper:*` |
+|---------|:----------------:|:----------:|:-------:|:--------:|:----------:|
+| `exact` |        ✅        |     🚧     |   🚧    |    🚧    |     ✅     |
 
 Networks are specified in [CAIP-2](https://chainagnostic.org/CAIPs/caip-2)
 format (e.g. `eip155:84532` for Base Sepolia, `eip155:8453` for Base
@@ -23,6 +23,19 @@ mainnet, `eip155:42161` for Arbitrum One). The `exact` scheme supports
 both EIP-3009 `transferWithAuthorization` and Permit2
 `PermitWitnessTransferFrom` payloads on EVM chains; see the `--method`
 flag on `x402-client` to pick between them.
+
+### Casper
+
+Casper is addressed as `casper:casper` (mainnet) and `casper:casper-test`
+(testnet). Settlement uses wCSPR, a CEP-18 token with 9 decimals, so
+amounts are integer motes encoded as decimal strings; conversions that
+would lose sub-mote precision fail instead of truncating.
+
+Casper payments are authorized by the payer and broadcast by a Casper
+facilitator service, so `url` points at that service rather than a node
+RPC endpoint. It defaults to `https://x402-facilitator.cspr.cloud` and can
+be overridden through `url` in `config.toml` or the
+`CASPER_FACILITATOR_URL` environment variable.
 
 ## How to run
 

--- a/config.toml
+++ b/config.toml
@@ -11,10 +11,15 @@ scheme = "exact"
 #   eip155:84532  — Base Sepolia
 #   eip155:8453   — Base mainnet
 #   eip155:42161  — Arbitrum One
+#   casper:casper      — Casper mainnet
+#   casper:casper-test — Casper testnet
 network = "eip155:84532"
 
 # RPC endpoint the facilitator uses to verify and broadcast transactions
-# on the configured network.
+# on the configured network. For casper:* networks this is the base URL of
+# the Casper x402 facilitator service (default
+# https://x402-facilitator.cspr.cloud, overridable with the
+# CASPER_FACILITATOR_URL environment variable).
 url = "https://sepolia.base.org"
 
 # Private key of the facilitator's fee payer (hex, no 0x prefix). Leave

--- a/facilitator/casper.go
+++ b/facilitator/casper.go
@@ -1,0 +1,329 @@
+package facilitator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	casperscheme "github.com/gosuda/x402-facilitator/scheme/casper"
+	"github.com/gosuda/x402-facilitator/types"
+)
+
+var _ Facilitator = (*CasperFacilitator)(nil)
+
+// CasperFacilitatorURLEnv overrides the Casper facilitator base URL when no
+// URL is supplied through configuration.
+const CasperFacilitatorURLEnv = "CASPER_FACILITATOR_URL"
+
+// CasperFacilitator settles x402 "exact" payments on Casper. Casper payments
+// are CEP-18 (wCSPR, 9 decimals) transfers authorized by the payer and
+// broadcast by a Casper facilitator service, so this implementation delegates
+// verification and settlement over HTTP rather than signing locally.
+type CasperFacilitator struct {
+	scheme  types.Scheme
+	network string
+	client  *casperscheme.Client
+	assets  []string
+}
+
+// CasperFacilitatorOptions customizes the settlement asset allowlist.
+type CasperFacilitatorOptions struct {
+	// AssetContracts are CEP-18 contract hashes accepted for settlement. When
+	// empty, any syntactically valid contract hash configured by the payment
+	// requirements is accepted.
+	AssetContracts []string
+}
+
+// NewCasperFacilitator builds a Casper facilitator for a CAIP-2 Casper
+// network. privateKeyHex is unused: settlement fees are paid by the Casper
+// facilitator service.
+func NewCasperFacilitator(network string, url string, privateKeyHex string) (*CasperFacilitator, error) {
+	return NewCasperFacilitatorWithOptions(network, url, privateKeyHex, CasperFacilitatorOptions{})
+}
+
+// NewCasperFacilitatorWithOptions builds a Casper facilitator with an explicit
+// settlement asset allowlist.
+func NewCasperFacilitatorWithOptions(network string, url string, privateKeyHex string, opts CasperFacilitatorOptions) (*CasperFacilitator, error) {
+	if !casperscheme.IsCasperNetwork(network) {
+		return nil, fmt.Errorf("unsupported Casper network %q", network)
+	}
+	networkInfo := casperscheme.GetNetworkInfo(network)
+	if networkInfo == nil {
+		return nil, fmt.Errorf("unsupported Casper network %q", network)
+	}
+	if strings.TrimSpace(url) == "" {
+		url = strings.TrimSpace(os.Getenv(CasperFacilitatorURLEnv))
+	}
+	client := casperscheme.NewClientWithEndpoints(url, networkInfo.DefaultURLs)
+
+	assets := casperscheme.GetAssetTypes(network)
+	if opts.AssetContracts != nil {
+		assets = append([]string(nil), opts.AssetContracts...)
+	}
+	assets, err := casperAssetAllowlist(assets)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CasperFacilitator{
+		scheme:  types.Exact,
+		network: network,
+		client:  client,
+		assets:  assets,
+	}, nil
+}
+
+// Close releases the underlying HTTP connections.
+func (t *CasperFacilitator) Close() error {
+	if t == nil || t.client == nil {
+		return nil
+	}
+	return t.client.Close()
+}
+
+func casperAssetAllowlist(assets []string) ([]string, error) {
+	ordered := make([]string, 0, len(assets))
+	seen := make(map[string]struct{}, len(assets))
+	for _, asset := range assets {
+		asset = strings.TrimSpace(asset)
+		if asset == "" {
+			continue
+		}
+		hash := casperscheme.NormalizeContractHash(asset)
+		if hash == "" {
+			return nil, fmt.Errorf("invalid Casper asset contract hash: %s", asset)
+		}
+		if _, ok := seen[hash]; ok {
+			continue
+		}
+		seen[hash] = struct{}{}
+		ordered = append(ordered, asset)
+	}
+	return ordered, nil
+}
+
+func (t *CasperFacilitator) Verify(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements) (*types.PaymentVerifyResponse, error) {
+	if payload == nil || req == nil {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrInvalidPayloadFormat.Error(),
+		}, nil
+	}
+
+	casperPayload, err := casperscheme.PayloadFromMap(payload.Payload)
+	if err != nil {
+		return &types.PaymentVerifyResponse{
+			IsValid:        false,
+			InvalidReason:  invalidCasperPayloadReason(err),
+			InvalidMessage: err.Error(),
+		}, nil
+	}
+	payer := casperscheme.NormalizeAddress(casperPayload.Payer)
+
+	if invalid := t.validatePaymentEnvelope(payload, req, payer); invalid != nil {
+		return invalid, nil
+	}
+
+	if _, err := casperscheme.ParseMotes(req.Amount); err != nil {
+		return &types.PaymentVerifyResponse{
+			IsValid:        false,
+			InvalidReason:  types.ErrAmountMismatch.Error(),
+			InvalidMessage: err.Error(),
+			Payer:          payer,
+		}, nil
+	}
+
+	verified, err := t.client.Verify(ctx, payload, req)
+	if err != nil {
+		return nil, fmt.Errorf("casper verify failed: %w", err)
+	}
+	if !verified.IsValid {
+		return &types.PaymentVerifyResponse{
+			IsValid:        false,
+			InvalidReason:  casperInvalidReason(verified.InvalidReason),
+			InvalidMessage: verified.InvalidMessage,
+			Payer:          casperPayerOrDefault(verified.Payer, payer),
+		}, nil
+	}
+
+	return &types.PaymentVerifyResponse{
+		IsValid: true,
+		Payer:   casperPayerOrDefault(verified.Payer, payer),
+	}, nil
+}
+
+func (t *CasperFacilitator) Settle(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements) (*types.PaymentSettleResponse, error) {
+	network := types.Network("")
+	if req != nil {
+		network = types.Network(req.Network)
+	}
+
+	verified, err := t.Verify(ctx, payload, req)
+	if err != nil {
+		return nil, err
+	}
+	if !verified.IsValid {
+		return &types.PaymentSettleResponse{
+			Success:      false,
+			ErrorReason:  verified.InvalidReason,
+			ErrorMessage: verified.InvalidMessage,
+			Payer:        verified.Payer,
+			Network:      network,
+		}, nil
+	}
+
+	settled, err := t.client.Settle(ctx, payload, req)
+	if err != nil {
+		return &types.PaymentSettleResponse{
+			Success:      false,
+			ErrorReason:  types.ErrTransactionFailed.Error(),
+			ErrorMessage: err.Error(),
+			Payer:        verified.Payer,
+			Network:      network,
+		}, nil
+	}
+	if !settled.Success {
+		return &types.PaymentSettleResponse{
+			Success:      false,
+			ErrorReason:  casperErrorReason(settled.ErrorReason),
+			ErrorMessage: settled.ErrorMessage,
+			Payer:        casperPayerOrDefault(settled.Payer, verified.Payer),
+			Transaction:  settled.Transaction,
+			Network:      network,
+		}, nil
+	}
+
+	return &types.PaymentSettleResponse{
+		Success:     true,
+		Payer:       casperPayerOrDefault(settled.Payer, verified.Payer),
+		Transaction: settled.Transaction,
+		Network:     network,
+	}, nil
+}
+
+func (t *CasperFacilitator) Supported() *types.SupportedResponse {
+	return &types.SupportedResponse{
+		Kinds: []types.SupportedKind{{
+			X402Version: int(types.X402VersionV2),
+			Scheme:      string(t.scheme),
+			Network:     t.network,
+			Extra: map[string]interface{}{
+				"assetTransferMethod": "casper-cep18-facilitated-transfer",
+				"assets":              t.assets,
+				"decimals":            casperscheme.MoteDecimals,
+				"networkId":           casperscheme.GetNetworkID(t.network),
+				"networkName":         casperscheme.GetNetworkName(t.network),
+			},
+		}},
+		Extensions: []string{},
+		Signers:    map[string][]string{},
+	}
+}
+
+func (t *CasperFacilitator) validatePaymentEnvelope(payload *types.PaymentPayload, req *types.PaymentRequirements, payer string) *types.PaymentVerifyResponse {
+	if payload.X402Version != int(types.X402VersionV2) {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrInvalidPayloadFormat.Error(),
+			Payer:         payer,
+		}
+	}
+	if payload.Accepted.Scheme != string(t.scheme) || req.Scheme != string(t.scheme) {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrIncompatibleScheme.Error(),
+			Payer:         payer,
+		}
+	}
+	if payload.Accepted.Network != t.network || req.Network != t.network {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrNetworkMismatch.Error(),
+			Payer:         payer,
+		}
+	}
+	if !strings.EqualFold(strings.TrimSpace(payload.Accepted.Asset), strings.TrimSpace(req.Asset)) {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrTokenMismatch.Error(),
+			Payer:         payer,
+		}
+	}
+	if payload.Accepted.Amount != req.Amount {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrAmountMismatch.Error(),
+			Payer:         payer,
+		}
+	}
+	if casperscheme.NormalizeAddress(payload.Accepted.PayTo) != casperscheme.NormalizeAddress(req.PayTo) ||
+		casperscheme.NormalizeAddress(req.PayTo) == "" {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrRecipientMismatch.Error(),
+			Payer:         payer,
+		}
+	}
+	if !t.isSupportedAsset(req.Asset) {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrInvalidToken.Error(),
+			Payer:         payer,
+		}
+	}
+	return nil
+}
+
+func (t *CasperFacilitator) isSupportedAsset(asset string) bool {
+	_, ok := t.canonicalAsset(asset)
+	return ok
+}
+
+func (t *CasperFacilitator) canonicalAsset(asset string) (string, bool) {
+	if t == nil {
+		return "", false
+	}
+	hash := casperscheme.NormalizeContractHash(asset)
+	if hash == "" {
+		return "", false
+	}
+	if len(t.assets) == 0 {
+		return hash, true
+	}
+	for _, candidate := range t.assets {
+		if casperscheme.NormalizeContractHash(candidate) == hash {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
+func invalidCasperPayloadReason(err error) string {
+	if errors.Is(err, casperscheme.ErrEmptySignature) {
+		return types.ErrInvalidSignature.Error()
+	}
+	return types.ErrInvalidPayloadFormat.Error()
+}
+
+func casperInvalidReason(reason string) string {
+	if strings.TrimSpace(reason) == "" {
+		return types.ErrInvalidTransaction.Error()
+	}
+	return reason
+}
+
+func casperErrorReason(reason string) string {
+	if strings.TrimSpace(reason) == "" {
+		return types.ErrTransactionFailed.Error()
+	}
+	return reason
+}
+
+func casperPayerOrDefault(payer, fallback string) string {
+	if strings.TrimSpace(payer) != "" {
+		return payer
+	}
+	return fallback
+}

--- a/facilitator/casper_test.go
+++ b/facilitator/casper_test.go
@@ -157,8 +157,10 @@ func TestCasperFacilitatorVerifyEnvelopeValidation(t *testing.T) {
 			wantReason: types.ErrNetworkMismatch.Error(),
 		},
 		{
-			name:       "asset mismatch",
-			mutate:     func(p *types.PaymentPayload, _ *types.PaymentRequirements) { p.Accepted.Asset = "hash-" + casperTestContract },
+			name: "asset mismatch",
+			mutate: func(p *types.PaymentPayload, _ *types.PaymentRequirements) {
+				p.Accepted.Asset = "hash-" + casperTestContract
+			},
 			wantReason: types.ErrTokenMismatch.Error(),
 		},
 		{

--- a/facilitator/casper_test.go
+++ b/facilitator/casper_test.go
@@ -1,0 +1,434 @@
+package facilitator
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	casperscheme "github.com/gosuda/x402-facilitator/scheme/casper"
+	"github.com/gosuda/x402-facilitator/types"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	casperTestPayer    = "account-hash-1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff000"
+	casperTestPayTo    = "account-hash-aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+	casperTestContract = "1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff001"
+)
+
+func casperRequirements() *types.PaymentRequirements {
+	return &types.PaymentRequirements{
+		Scheme:            string(types.Exact),
+		Network:           casperscheme.NetworkTestnet,
+		Asset:             casperTestContract,
+		Amount:            "1000000000",
+		PayTo:             casperTestPayTo,
+		MaxTimeoutSeconds: 60,
+	}
+}
+
+func casperPayload() *types.PaymentPayload {
+	return &types.PaymentPayload{
+		X402Version: int(types.X402VersionV2),
+		Payload: map[string]interface{}{
+			"signature": "01aabb",
+			"payer":     casperTestPayer,
+			"deploy":    map[string]interface{}{"hash": "aabb"},
+		},
+		Accepted: *casperRequirements(),
+	}
+}
+
+func newCasperTestFacilitator(t *testing.T, handler http.HandlerFunc) *CasperFacilitator {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	facilitator, err := NewCasperFacilitatorWithOptions(
+		casperscheme.NetworkTestnet,
+		server.URL,
+		"",
+		CasperFacilitatorOptions{AssetContracts: []string{casperTestContract}},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = facilitator.Close() })
+	return facilitator
+}
+
+func TestNewCasperFacilitator(t *testing.T) {
+	tests := []struct {
+		name    string
+		network string
+		wantErr bool
+	}{
+		{name: "mainnet", network: casperscheme.NetworkMainnet},
+		{name: "testnet", network: casperscheme.NetworkTestnet},
+		{name: "unsupported casper network", network: "casper:casper-dev", wantErr: true},
+		{name: "wrong namespace", network: "eip155:8453", wantErr: true},
+		{name: "empty", network: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			facilitator, err := NewCasperFacilitator(tt.network, "", "")
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Nil(t, facilitator)
+				return
+			}
+			require.NoError(t, err)
+			require.NoError(t, facilitator.Close())
+		})
+	}
+}
+
+func TestNewCasperFacilitatorUsesEnvURLWhenUnset(t *testing.T) {
+	t.Setenv(CasperFacilitatorURLEnv, "https://casper.example.invalid")
+
+	facilitator, err := NewCasperFacilitator(casperscheme.NetworkMainnet, "", "")
+	require.NoError(t, err)
+	defer facilitator.Close()
+	require.Equal(t, "https://casper.example.invalid", facilitator.client.ActiveEndpoint())
+}
+
+func TestNewCasperFacilitatorRejectsInvalidAssetContract(t *testing.T) {
+	_, err := NewCasperFacilitatorWithOptions(
+		casperscheme.NetworkTestnet,
+		"https://casper.example.invalid",
+		"",
+		CasperFacilitatorOptions{AssetContracts: []string{"not-a-contract-hash"}},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid Casper asset contract hash")
+}
+
+func TestCasperFacilitatorSupported(t *testing.T) {
+	facilitator, err := NewCasperFacilitatorWithOptions(
+		casperscheme.NetworkMainnet,
+		"https://casper.example.invalid",
+		"",
+		CasperFacilitatorOptions{AssetContracts: []string{casperTestContract}},
+	)
+	require.NoError(t, err)
+	defer facilitator.Close()
+
+	supported := facilitator.Supported()
+	require.NotNil(t, supported)
+	require.Len(t, supported.Kinds, 1)
+
+	kind := supported.Kinds[0]
+	require.Equal(t, int(types.X402VersionV2), kind.X402Version)
+	require.Equal(t, string(types.Exact), kind.Scheme)
+	require.Equal(t, casperscheme.NetworkMainnet, kind.Network)
+	require.Equal(t, "casper", kind.Extra["networkId"])
+	require.Equal(t, "Casper Mainnet", kind.Extra["networkName"])
+	require.Equal(t, casperscheme.MoteDecimals, kind.Extra["decimals"])
+	require.Equal(t, []string{casperTestContract}, kind.Extra["assets"])
+	require.NotNil(t, supported.Extensions)
+	require.NotNil(t, supported.Signers)
+}
+
+func TestCasperFacilitatorVerifyEnvelopeValidation(t *testing.T) {
+	tests := []struct {
+		name       string
+		mutate     func(payload *types.PaymentPayload, req *types.PaymentRequirements)
+		wantReason string
+	}{
+		{
+			name:       "x402 version mismatch",
+			mutate:     func(p *types.PaymentPayload, _ *types.PaymentRequirements) { p.X402Version = 1 },
+			wantReason: types.ErrInvalidPayloadFormat.Error(),
+		},
+		{
+			name: "scheme mismatch",
+			mutate: func(p *types.PaymentPayload, r *types.PaymentRequirements) {
+				p.Accepted.Scheme = "upto"
+				r.Scheme = "upto"
+			},
+			wantReason: types.ErrIncompatibleScheme.Error(),
+		},
+		{
+			name: "network mismatch",
+			mutate: func(p *types.PaymentPayload, r *types.PaymentRequirements) {
+				p.Accepted.Network = casperscheme.NetworkMainnet
+				r.Network = casperscheme.NetworkMainnet
+			},
+			wantReason: types.ErrNetworkMismatch.Error(),
+		},
+		{
+			name:       "asset mismatch",
+			mutate:     func(p *types.PaymentPayload, _ *types.PaymentRequirements) { p.Accepted.Asset = "hash-" + casperTestContract },
+			wantReason: types.ErrTokenMismatch.Error(),
+		},
+		{
+			name:       "amount mismatch",
+			mutate:     func(p *types.PaymentPayload, _ *types.PaymentRequirements) { p.Accepted.Amount = "2000000000" },
+			wantReason: types.ErrAmountMismatch.Error(),
+		},
+		{
+			name:       "recipient mismatch",
+			mutate:     func(p *types.PaymentPayload, _ *types.PaymentRequirements) { p.Accepted.PayTo = casperTestPayer },
+			wantReason: types.ErrRecipientMismatch.Error(),
+		},
+		{
+			name: "invalid recipient",
+			mutate: func(p *types.PaymentPayload, r *types.PaymentRequirements) {
+				p.Accepted.PayTo = "not-an-address"
+				r.PayTo = "not-an-address"
+			},
+			wantReason: types.ErrRecipientMismatch.Error(),
+		},
+		{
+			name: "unsupported asset",
+			mutate: func(p *types.PaymentPayload, r *types.PaymentRequirements) {
+				other := "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff0"
+				p.Accepted.Asset = other
+				r.Asset = other
+			},
+			wantReason: types.ErrInvalidToken.Error(),
+		},
+		{
+			name: "invalid amount",
+			mutate: func(p *types.PaymentPayload, r *types.PaymentRequirements) {
+				p.Accepted.Amount = "1.5"
+				r.Amount = "1.5"
+			},
+			wantReason: types.ErrAmountMismatch.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			facilitator := newCasperTestFacilitator(t, func(w http.ResponseWriter, r *http.Request) {
+				t.Fatal("remote facilitator should not be called for locally invalid payments")
+			})
+
+			payload, req := casperPayload(), casperRequirements()
+			tt.mutate(payload, req)
+
+			response, err := facilitator.Verify(context.Background(), payload, req)
+			require.NoError(t, err)
+			require.False(t, response.IsValid)
+			require.Equal(t, tt.wantReason, response.InvalidReason)
+		})
+	}
+}
+
+func TestCasperFacilitatorVerifyRejectsNilArguments(t *testing.T) {
+	facilitator := newCasperTestFacilitator(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("remote facilitator should not be called")
+	})
+
+	response, err := facilitator.Verify(context.Background(), nil, casperRequirements())
+	require.NoError(t, err)
+	require.False(t, response.IsValid)
+	require.Equal(t, types.ErrInvalidPayloadFormat.Error(), response.InvalidReason)
+
+	response, err = facilitator.Verify(context.Background(), casperPayload(), nil)
+	require.NoError(t, err)
+	require.False(t, response.IsValid)
+	require.Equal(t, types.ErrInvalidPayloadFormat.Error(), response.InvalidReason)
+}
+
+func TestCasperFacilitatorVerifyRejectsMalformedPayload(t *testing.T) {
+	tests := []struct {
+		name       string
+		payload    map[string]interface{}
+		wantReason string
+	}{
+		{
+			name:       "missing signature",
+			payload:    map[string]interface{}{"payer": casperTestPayer, "deploy": map[string]interface{}{"hash": "aabb"}},
+			wantReason: types.ErrInvalidSignature.Error(),
+		},
+		{
+			name:       "missing deploy",
+			payload:    map[string]interface{}{"signature": "01aabb", "payer": casperTestPayer},
+			wantReason: types.ErrInvalidPayloadFormat.Error(),
+		},
+		{
+			name:       "invalid payer",
+			payload:    map[string]interface{}{"signature": "01aabb", "payer": "nope", "deploy": map[string]interface{}{"hash": "aabb"}},
+			wantReason: types.ErrInvalidPayloadFormat.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			facilitator := newCasperTestFacilitator(t, func(w http.ResponseWriter, r *http.Request) {
+				t.Fatal("remote facilitator should not be called for malformed payloads")
+			})
+
+			payload := casperPayload()
+			payload.Payload = tt.payload
+
+			response, err := facilitator.Verify(context.Background(), payload, casperRequirements())
+			require.NoError(t, err)
+			require.False(t, response.IsValid)
+			require.Equal(t, tt.wantReason, response.InvalidReason)
+		})
+	}
+}
+
+func TestCasperFacilitatorVerifyDelegatesToRemote(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		wantValid  bool
+		wantReason string
+		wantPayer  string
+	}{
+		{
+			name:      "remote accepts",
+			body:      `{"isValid":true,"payer":"` + casperTestPayer + `"}`,
+			wantValid: true,
+			wantPayer: casperTestPayer,
+		},
+		{
+			name:       "remote rejects with reason",
+			body:       `{"isValid":false,"invalidReason":"insufficient_balance"}`,
+			wantReason: "insufficient_balance",
+			wantPayer:  casperTestPayer,
+		},
+		{
+			name:       "remote rejects without reason",
+			body:       `{"isValid":false}`,
+			wantReason: types.ErrInvalidTransaction.Error(),
+			wantPayer:  casperTestPayer,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			facilitator := newCasperTestFacilitator(t, func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, casperscheme.VerifyPath, r.URL.Path)
+				_, _ = w.Write([]byte(tt.body))
+			})
+
+			response, err := facilitator.Verify(context.Background(), casperPayload(), casperRequirements())
+			require.NoError(t, err)
+			require.Equal(t, tt.wantValid, response.IsValid)
+			require.Equal(t, tt.wantReason, response.InvalidReason)
+			require.Equal(t, tt.wantPayer, response.Payer)
+		})
+	}
+}
+
+func TestCasperFacilitatorVerifyPropagatesTransportError(t *testing.T) {
+	facilitator := newCasperTestFacilitator(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	response, err := facilitator.Verify(context.Background(), casperPayload(), casperRequirements())
+	require.Error(t, err)
+	require.Nil(t, response)
+	require.Contains(t, err.Error(), "casper verify failed")
+}
+
+func TestCasperFacilitatorSettle(t *testing.T) {
+	tests := []struct {
+		name        string
+		verifyBody  string
+		settleBody  string
+		settleCode  int
+		wantSuccess bool
+		wantReason  string
+		wantTx      string
+	}{
+		{
+			name:        "settles successfully",
+			verifyBody:  `{"isValid":true,"payer":"` + casperTestPayer + `"}`,
+			settleBody:  `{"success":true,"transaction":"deadbeef","payer":"` + casperTestPayer + `"}`,
+			settleCode:  http.StatusOK,
+			wantSuccess: true,
+			wantTx:      "deadbeef",
+		},
+		{
+			name:       "verification failure short circuits settlement",
+			verifyBody: `{"isValid":false,"invalidReason":"insufficient_balance"}`,
+			settleCode: http.StatusOK,
+			wantReason: "insufficient_balance",
+		},
+		{
+			name:       "remote settlement failure",
+			verifyBody: `{"isValid":true,"payer":"` + casperTestPayer + `"}`,
+			settleBody: `{"success":false,"errorReason":"transaction_failed","errorMessage":"deploy reverted"}`,
+			settleCode: http.StatusOK,
+			wantReason: "transaction_failed",
+		},
+		{
+			name:       "remote settlement transport error",
+			verifyBody: `{"isValid":true,"payer":"` + casperTestPayer + `"}`,
+			settleBody: `{"message":"upstream unavailable"}`,
+			settleCode: http.StatusBadGateway,
+			wantReason: types.ErrTransactionFailed.Error(),
+		},
+		{
+			name:       "remote settlement failure without reason",
+			verifyBody: `{"isValid":true,"payer":"` + casperTestPayer + `"}`,
+			settleBody: `{"success":false}`,
+			settleCode: http.StatusOK,
+			wantReason: types.ErrTransactionFailed.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var settleCalled bool
+			facilitator := newCasperTestFacilitator(t, func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case casperscheme.VerifyPath:
+					_, _ = w.Write([]byte(tt.verifyBody))
+				case casperscheme.SettlePath:
+					settleCalled = true
+					w.WriteHeader(tt.settleCode)
+					_, _ = w.Write([]byte(tt.settleBody))
+				default:
+					t.Fatalf("unexpected path %s", r.URL.Path)
+				}
+			})
+
+			response, err := facilitator.Settle(context.Background(), casperPayload(), casperRequirements())
+			require.NoError(t, err)
+			require.Equal(t, tt.wantSuccess, response.Success)
+			require.Equal(t, tt.wantTx, response.Transaction)
+			require.Equal(t, types.Network(casperscheme.NetworkTestnet), response.Network)
+			if tt.wantReason != "" {
+				require.Equal(t, tt.wantReason, response.ErrorReason)
+			}
+			if tt.name == "verification failure short circuits settlement" {
+				require.False(t, settleCalled)
+			}
+		})
+	}
+}
+
+func TestNewFacilitatorRoutesCasperNetworks(t *testing.T) {
+	tests := []struct {
+		name    string
+		scheme  types.Scheme
+		network string
+		wantErr bool
+	}{
+		{name: "mainnet", scheme: types.Exact, network: casperscheme.NetworkMainnet},
+		{name: "testnet", scheme: types.Exact, network: casperscheme.NetworkTestnet},
+		{name: "unsupported casper network", scheme: types.Exact, network: "casper:casper-dev", wantErr: true},
+		{name: "unsupported scheme", scheme: types.Scheme("upto"), network: casperscheme.NetworkMainnet, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance, err := NewFacilitator(tt.scheme, tt.network, "https://casper.example.invalid", "")
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			casperFacilitator, ok := instance.(*CasperFacilitator)
+			require.True(t, ok)
+			require.Equal(t, tt.network, casperFacilitator.Supported().Kinds[0].Network)
+			require.NoError(t, casperFacilitator.Close())
+		})
+	}
+}

--- a/facilitator/iface.go
+++ b/facilitator/iface.go
@@ -29,7 +29,9 @@ func NewFacilitator(scheme types.Scheme, network, rpcUrl string, privateKeyHex s
 		return NewSuiFacilitator(network, rpcUrl, privateKeyHex)
 	case strings.HasPrefix(network, "tron:"):
 		return NewTronFacilitator(network, rpcUrl, privateKeyHex)
+	case strings.HasPrefix(network, "casper:"):
+		return NewCasperFacilitator(network, rpcUrl, privateKeyHex)
 	default:
-		return nil, fmt.Errorf("unsupported network %q: expected a CAIP-2 identifier (eip155:*, solana:*, sui:*, tron:*)", network)
+		return nil, fmt.Errorf("unsupported network %q: expected a CAIP-2 identifier (eip155:*, solana:*, sui:*, tron:*, casper:*)", network)
 	}
 }

--- a/scheme/casper/casper.go
+++ b/scheme/casper/casper.go
@@ -1,0 +1,217 @@
+// Package casper implements the x402 v2 "exact" scheme primitives for the
+// Casper network family (CAIP-2 `casper:casper` and `casper:casper-test`).
+//
+// Settlement uses wCSPR, a CEP-18 token with 9 decimals; the atomic unit is a
+// mote. All amounts crossing the wire are integer motes encoded as decimal
+// strings, mirroring the rest of this facilitator.
+package casper
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+)
+
+const (
+	// MoteDecimals is the number of decimals of CSPR and wCSPR. One CSPR is
+	// 10^9 motes.
+	MoteDecimals uint8 = 9
+
+	// AccountHashPrefix is the textual prefix of a Casper account hash.
+	AccountHashPrefix = "account-hash-"
+	// ContractHashPrefix is the textual prefix of a Casper contract hash.
+	ContractHashPrefix = "hash-"
+
+	// WCSPRSymbol is the symbol of the settlement asset.
+	WCSPRSymbol = "WCSPR"
+)
+
+var (
+	ErrEmptyPayload      = errors.New("empty_payload")
+	ErrEmptySignature    = errors.New("empty_signature")
+	ErrEmptyTransaction  = errors.New("empty_transaction")
+	ErrInvalidAddress    = errors.New("invalid_address")
+	ErrInvalidAsset      = errors.New("invalid_asset")
+	ErrInvalidAmount     = errors.New("invalid_amount")
+	ErrInvalidNetwork    = errors.New("invalid_network")
+	ErrUnsupportedScheme = errors.New("unsupported_scheme")
+
+	// ErrSubMotePrecision is returned when a decimal CSPR amount carries more
+	// precision than a mote can represent. Truncating would silently change
+	// the payment amount, so the conversion fails instead.
+	ErrSubMotePrecision = errors.New("sub_mote_precision")
+)
+
+// Payload is the x402 Casper "exact" scheme payload. Deploy is the JSON
+// encoded signed Casper Deploy (or Transaction) the payer authorized, and
+// Signature is the payer signature in hex, as produced by the Casper x402
+// client SDKs.
+type Payload struct {
+	Signature string          `json:"signature"`
+	Payer     string          `json:"payer"`
+	Deploy    json.RawMessage `json:"deploy"`
+}
+
+// ParsePayload decodes and validates a raw x402 Casper payload.
+func ParsePayload(raw []byte) (*Payload, error) {
+	if len(raw) == 0 {
+		return nil, ErrEmptyPayload
+	}
+	var payload Payload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, fmt.Errorf("invalid_payload: %w", err)
+	}
+	if strings.TrimSpace(payload.Signature) == "" {
+		return nil, ErrEmptySignature
+	}
+	if len(payload.Deploy) == 0 || strings.TrimSpace(string(payload.Deploy)) == "null" {
+		return nil, ErrEmptyTransaction
+	}
+	if NormalizeAddress(payload.Payer) == "" {
+		return nil, ErrInvalidAddress
+	}
+	return &payload, nil
+}
+
+// PayloadFromMap decodes an x402 payload carried as a generic JSON object.
+func PayloadFromMap(value map[string]interface{}) (*Payload, error) {
+	if value == nil {
+		return nil, ErrEmptyPayload
+	}
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePayload(raw)
+}
+
+// NormalizeAsset lower-cases an asset identifier for comparison.
+func NormalizeAsset(asset string) string {
+	return strings.ToLower(strings.TrimSpace(asset))
+}
+
+// NormalizeAddress validates and canonicalizes a Casper payer or recipient
+// identifier. Accepted forms are an `account-hash-<64 hex>` string and a hex
+// encoded public key (ed25519 `01` + 64 hex, secp256k1 `02` + 66 hex). The
+// empty string is returned when the input is not a valid Casper address.
+func NormalizeAddress(address string) string {
+	address = strings.ToLower(strings.TrimSpace(address))
+	if address == "" {
+		return ""
+	}
+	if rest, ok := strings.CutPrefix(address, AccountHashPrefix); ok {
+		if !isHex(rest, 64) {
+			return ""
+		}
+		return AccountHashPrefix + rest
+	}
+	switch {
+	case strings.HasPrefix(address, "01") && isHex(address, 66):
+		return address
+	case strings.HasPrefix(address, "02") && isHex(address, 68):
+		return address
+	default:
+		return ""
+	}
+}
+
+// NormalizeContractHash validates and canonicalizes a CEP-18 contract hash.
+// Both the bare 64 hex character form and the `hash-` prefixed form are
+// accepted; the bare lower-case form is returned.
+func NormalizeContractHash(contract string) string {
+	contract = strings.ToLower(strings.TrimSpace(contract))
+	contract = strings.TrimPrefix(contract, ContractHashPrefix)
+	contract = strings.TrimPrefix(contract, "contract-")
+	if !isHex(contract, 64) {
+		return ""
+	}
+	return contract
+}
+
+// ParseMotes parses an integer mote amount encoded as a decimal string.
+func ParseMotes(amount string) (*big.Int, error) {
+	amount = strings.TrimSpace(amount)
+	if amount == "" {
+		return nil, ErrInvalidAmount
+	}
+	motes, ok := new(big.Int).SetString(amount, 10)
+	if !ok || motes.Sign() < 0 {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidAmount, amount)
+	}
+	return motes, nil
+}
+
+// CSPRToMotes converts a decimal CSPR amount to motes. Amounts carrying more
+// than MoteDecimals fractional digits are rejected with ErrSubMotePrecision
+// rather than truncated, so a payment can never be silently under-settled.
+func CSPRToMotes(amount string) (*big.Int, error) {
+	amount = strings.TrimSpace(amount)
+	if amount == "" {
+		return nil, ErrInvalidAmount
+	}
+	if strings.HasPrefix(amount, "-") {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidAmount, amount)
+	}
+	whole, frac, hasFrac := strings.Cut(amount, ".")
+	if whole == "" {
+		whole = "0"
+	}
+	if !isDigits(whole) || (hasFrac && !isDigits(frac)) {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidAmount, amount)
+	}
+	if len(frac) > int(MoteDecimals) {
+		if strings.Trim(frac[MoteDecimals:], "0") != "" {
+			return nil, fmt.Errorf("%w: %s has more than %d decimals", ErrSubMotePrecision, amount, MoteDecimals)
+		}
+		frac = frac[:MoteDecimals]
+	}
+	frac += strings.Repeat("0", int(MoteDecimals)-len(frac))
+	motes, ok := new(big.Int).SetString(whole+frac, 10)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidAmount, amount)
+	}
+	return motes, nil
+}
+
+// MotesToCSPR renders an integer mote amount as a decimal CSPR string. The
+// conversion is exact: no rounding is applied and trailing fractional zeros
+// are trimmed.
+func MotesToCSPR(motes *big.Int) string {
+	if motes == nil {
+		return "0"
+	}
+	unit := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(MoteDecimals)), nil)
+	whole, frac := new(big.Int).QuoRem(new(big.Int).Abs(motes), unit, new(big.Int))
+	sign := ""
+	if motes.Sign() < 0 {
+		sign = "-"
+	}
+	if frac.Sign() == 0 {
+		return sign + whole.String()
+	}
+	digits := strings.TrimRight(fmt.Sprintf("%0*s", MoteDecimals, frac.String()), "0")
+	return sign + whole.String() + "." + digits
+}
+
+func isHex(value string, length int) bool {
+	if len(value) != length {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}
+
+func isDigits(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/scheme/casper/casper_test.go
+++ b/scheme/casper/casper_test.go
@@ -1,0 +1,270 @@
+package casper
+
+import (
+	"encoding/json"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeAddress(t *testing.T) {
+	const accountHash = "account-hash-1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff000"
+	const ed25519Key = "011b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff000"
+	const secp256k1Key = "021b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff000ab"
+
+	tests := []struct {
+		name    string
+		address string
+		want    string
+	}{
+		{"account hash", accountHash, accountHash},
+		{"account hash upper case", "ACCOUNT-HASH-1B2C3D4E5F60718293A4B5C6D7E8F90112233445566778899AABBCCDDEEFF000", accountHash},
+		{"account hash padded", "  " + accountHash + "  ", accountHash},
+		{"ed25519 public key", ed25519Key, ed25519Key},
+		{"secp256k1 public key", secp256k1Key, secp256k1Key},
+		{"empty", "", ""},
+		{"account hash too short", "account-hash-1b2c3d", ""},
+		{"account hash not hex", "account-hash-zz2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff000", ""},
+		{"unknown key prefix", "031b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff000", ""},
+		{"ed25519 wrong length", "0117e5a20d", ""},
+		{"evm address", "0x1234567890123456789012345678901234567890", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, NormalizeAddress(tt.address))
+		})
+	}
+}
+
+func TestNormalizeContractHash(t *testing.T) {
+	const hash = "1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff001"
+
+	tests := []struct {
+		name     string
+		contract string
+		want     string
+	}{
+		{"bare hash", hash, hash},
+		{"hash prefixed", "hash-" + hash, hash},
+		{"contract prefixed", "contract-" + hash, hash},
+		{"upper case", "HASH-1B2C3D4E5F60718293A4B5C6D7E8F90112233445566778899AABBCCDDEEFF001", hash},
+		{"empty", "", ""},
+		{"too short", "1b2c3d", ""},
+		{"not hex", "zz2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff001", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, NormalizeContractHash(tt.contract))
+		})
+	}
+}
+
+func TestParseMotes(t *testing.T) {
+	tests := []struct {
+		name    string
+		amount  string
+		want    string
+		wantErr error
+	}{
+		{name: "zero", amount: "0", want: "0"},
+		{name: "one mote", amount: "1", want: "1"},
+		{name: "one cspr", amount: "1000000000", want: "1000000000"},
+		{name: "padded", amount: " 2500000000 ", want: "2500000000"},
+		{name: "large", amount: "340282366920938463463374607431768211455", want: "340282366920938463463374607431768211455"},
+		{name: "empty", amount: "", wantErr: ErrInvalidAmount},
+		{name: "negative", amount: "-1", wantErr: ErrInvalidAmount},
+		{name: "decimal", amount: "1.5", wantErr: ErrInvalidAmount},
+		{name: "not a number", amount: "abc", wantErr: ErrInvalidAmount},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			motes, err := ParseMotes(tt.amount)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, motes.String())
+		})
+	}
+}
+
+func TestCSPRToMotes(t *testing.T) {
+	tests := []struct {
+		name    string
+		amount  string
+		want    string
+		wantErr error
+	}{
+		{name: "whole", amount: "1", want: "1000000000"},
+		{name: "zero", amount: "0", want: "0"},
+		{name: "fractional", amount: "1.5", want: "1500000000"},
+		{name: "one mote", amount: "0.000000001", want: "1"},
+		{name: "leading dot", amount: ".25", want: "250000000"},
+		{name: "trailing zeros beyond precision", amount: "1.5000000000000", want: "1500000000"},
+		{name: "max precision", amount: "12.123456789", want: "12123456789"},
+		{name: "sub-mote precision rejected", amount: "0.0000000001", wantErr: ErrSubMotePrecision},
+		{name: "sub-mote precision rejected on large amount", amount: "1.1234567891", wantErr: ErrSubMotePrecision},
+		{name: "negative", amount: "-1", wantErr: ErrInvalidAmount},
+		{name: "empty", amount: "", wantErr: ErrInvalidAmount},
+		{name: "not a number", amount: "1.2.3", wantErr: ErrInvalidAmount},
+		{name: "letters", amount: "1e9", wantErr: ErrInvalidAmount},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			motes, err := CSPRToMotes(tt.amount)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				require.Nil(t, motes)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, motes.String())
+		})
+	}
+}
+
+func TestMotesToCSPRRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		motes string
+		want  string
+	}{
+		{"zero", "0", "0"},
+		{"one mote", "1", "0.000000001"},
+		{"one cspr", "1000000000", "1"},
+		{"fractional", "1500000000", "1.5"},
+		{"max precision", "12123456789", "12.123456789"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			motes, ok := new(big.Int).SetString(tt.motes, 10)
+			require.True(t, ok)
+			cspr := MotesToCSPR(motes)
+			require.Equal(t, tt.want, cspr)
+
+			back, err := CSPRToMotes(cspr)
+			require.NoError(t, err)
+			require.Equal(t, tt.motes, back.String())
+		})
+	}
+
+	require.Equal(t, "0", MotesToCSPR(nil))
+}
+
+func TestParsePayload(t *testing.T) {
+	const payer = "account-hash-1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff000"
+
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr error
+	}{
+		{
+			name: "valid",
+			raw:  `{"signature":"01aabb","payer":"` + payer + `","deploy":{"hash":"aabb"}}`,
+		},
+		{
+			name:    "empty signature",
+			raw:     `{"signature":"","payer":"` + payer + `","deploy":{"hash":"aabb"}}`,
+			wantErr: ErrEmptySignature,
+		},
+		{
+			name:    "missing deploy",
+			raw:     `{"signature":"01aabb","payer":"` + payer + `"}`,
+			wantErr: ErrEmptyTransaction,
+		},
+		{
+			name:    "null deploy",
+			raw:     `{"signature":"01aabb","payer":"` + payer + `","deploy":null}`,
+			wantErr: ErrEmptyTransaction,
+		},
+		{
+			name:    "invalid payer",
+			raw:     `{"signature":"01aabb","payer":"not-an-address","deploy":{"hash":"aabb"}}`,
+			wantErr: ErrInvalidAddress,
+		},
+		{
+			name:    "empty",
+			raw:     ``,
+			wantErr: ErrEmptyPayload,
+		},
+		{
+			name: "malformed json",
+			raw:  `{"signature":`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload, err := ParsePayload([]byte(tt.raw))
+			switch {
+			case tt.wantErr != nil:
+				require.ErrorIs(t, err, tt.wantErr)
+				require.Nil(t, payload)
+			case tt.name == "malformed json":
+				require.Error(t, err)
+				require.Nil(t, payload)
+			default:
+				require.NoError(t, err)
+				require.Equal(t, payer, NormalizeAddress(payload.Payer))
+				require.NotEmpty(t, payload.Signature)
+			}
+		})
+	}
+}
+
+func TestPayloadFromMap(t *testing.T) {
+	const payer = "account-hash-1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff000"
+
+	payload, err := PayloadFromMap(map[string]interface{}{
+		"signature": "01aabb",
+		"payer":     payer,
+		"deploy":    map[string]interface{}{"hash": "aabb"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "01aabb", payload.Signature)
+	require.Equal(t, payer, payload.Payer)
+	require.JSONEq(t, `{"hash":"aabb"}`, string(payload.Deploy))
+
+	_, err = PayloadFromMap(nil)
+	require.ErrorIs(t, err, ErrEmptyPayload)
+
+	_, err = PayloadFromMap(map[string]interface{}{"signature": "01aabb"})
+	require.ErrorIs(t, err, ErrEmptyTransaction)
+}
+
+func TestPayloadJSONRoundTrip(t *testing.T) {
+	const payer = "account-hash-1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff000"
+
+	original := Payload{
+		Signature: "01aabb",
+		Payer:     payer,
+		Deploy:    json.RawMessage(`{"hash":"aabb"}`),
+	}
+	encoded, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	decoded, err := ParsePayload(encoded)
+	require.NoError(t, err)
+	require.Equal(t, original.Signature, decoded.Signature)
+	require.Equal(t, original.Payer, decoded.Payer)
+	require.JSONEq(t, string(original.Deploy), string(decoded.Deploy))
+}
+
+func TestNormalizeAsset(t *testing.T) {
+	require.Equal(t, "wcspr", NormalizeAsset("  WCSPR "))
+	require.Equal(t, "", NormalizeAsset("   "))
+}
+
+func TestErrorsAreDistinct(t *testing.T) {
+	require.False(t, errors.Is(ErrSubMotePrecision, ErrInvalidAmount))
+	require.False(t, errors.Is(ErrInvalidAddress, ErrInvalidAsset))
+}

--- a/scheme/casper/chaincfg.go
+++ b/scheme/casper/chaincfg.go
@@ -1,0 +1,190 @@
+package casper
+
+import (
+	"maps"
+	"slices"
+	"strings"
+)
+
+const (
+	// NetworkMainnet is the CAIP-2 identifier of Casper mainnet.
+	NetworkMainnet = "casper:casper"
+	// NetworkTestnet is the CAIP-2 identifier of Casper testnet.
+	NetworkTestnet = "casper:casper-test"
+
+	// NetworkNamespace is the CAIP-2 namespace of the Casper network family.
+	NetworkNamespace = "casper"
+
+	// DefaultFacilitatorURL is the hosted Casper x402 facilitator operated on
+	// cspr.cloud. Deployments can override it via configuration.
+	DefaultFacilitatorURL = "https://x402-facilitator.cspr.cloud"
+)
+
+// NetworkInfo describes a supported Casper network.
+type NetworkInfo struct {
+	Network     string
+	NetworkName string
+	// NetworkID is the Casper chain name used in deploy headers.
+	NetworkID string
+	// DefaultURLs are the facilitator endpoints tried in order.
+	DefaultURLs []string
+	// AssetContracts maps an asset symbol to its CEP-18 contract hash. It is
+	// empty by default: CEP-18 tokens are addressed by contract hash and the
+	// wCSPR hash is supplied per deployment through configuration, so no
+	// contract hash is hard-coded here.
+	AssetContracts map[string]string
+	// AssetDecimals maps an asset symbol to its decimals.
+	AssetDecimals map[string]uint8
+}
+
+// IsCasperNetwork reports whether the CAIP-2 identifier belongs to the Casper
+// namespace.
+func IsCasperNetwork(network string) bool {
+	return strings.HasPrefix(strings.TrimSpace(network), NetworkNamespace+":")
+}
+
+// ParseNetwork splits a CAIP-2 Casper identifier into its namespace and
+// reference, validating that the network is supported.
+func ParseNetwork(network string) (namespace string, reference string, err error) {
+	network = strings.TrimSpace(network)
+	namespace, reference, ok := strings.Cut(network, ":")
+	if !ok || namespace != NetworkNamespace || reference == "" {
+		return "", "", ErrInvalidNetwork
+	}
+	if _, supported := networkInfo[network]; !supported {
+		return "", "", ErrInvalidNetwork
+	}
+	return namespace, reference, nil
+}
+
+// GetNetworkInfo returns a copy of the configuration for a Casper network, or
+// nil when the network is not supported.
+func GetNetworkInfo(network string) *NetworkInfo {
+	info, ok := networkInfo[strings.TrimSpace(network)]
+	if !ok {
+		return nil
+	}
+	info.DefaultURLs = slices.Clone(info.DefaultURLs)
+	info.AssetContracts = maps.Clone(info.AssetContracts)
+	info.AssetDecimals = maps.Clone(info.AssetDecimals)
+	return &info
+}
+
+// GetNetworkName returns the human readable name of a Casper network.
+func GetNetworkName(network string) string {
+	info := GetNetworkInfo(network)
+	if info == nil {
+		return ""
+	}
+	return info.NetworkName
+}
+
+// GetNetworkID returns the Casper chain name of a network.
+func GetNetworkID(network string) string {
+	info := GetNetworkInfo(network)
+	if info == nil {
+		return ""
+	}
+	return info.NetworkID
+}
+
+// GetDefaultURLs returns the default facilitator endpoints for a network.
+func GetDefaultURLs(network string) []string {
+	info := GetNetworkInfo(network)
+	if info == nil {
+		return nil
+	}
+	return slices.Clone(info.DefaultURLs)
+}
+
+// GetAssetTypes returns the settlement assets supported on a network, as
+// CEP-18 contract hashes.
+func GetAssetTypes(network string) []string {
+	info := GetNetworkInfo(network)
+	if info == nil {
+		return nil
+	}
+	symbols := make([]string, 0, len(info.AssetContracts))
+	for symbol := range info.AssetContracts {
+		symbols = append(symbols, symbol)
+	}
+	slices.Sort(symbols)
+	assets := make([]string, 0, len(symbols))
+	for _, symbol := range symbols {
+		assets = append(assets, info.AssetContracts[symbol])
+	}
+	return assets
+}
+
+// GetAssetContract resolves an asset symbol or contract hash to the canonical
+// CEP-18 contract hash configured for the network.
+func GetAssetContract(network, asset string) (string, bool) {
+	info := GetNetworkInfo(network)
+	if info == nil {
+		return "", false
+	}
+	normalized := NormalizeAsset(asset)
+	for symbol, contract := range info.AssetContracts {
+		if NormalizeAsset(symbol) == normalized {
+			return contract, true
+		}
+	}
+	hash := NormalizeContractHash(asset)
+	if hash == "" {
+		return "", false
+	}
+	for _, contract := range info.AssetContracts {
+		if NormalizeContractHash(contract) == hash {
+			return contract, true
+		}
+	}
+	// No symbol mapping is configured for this contract hash. CEP-18 tokens
+	// are addressed by contract hash on Casper, so a syntactically valid hash
+	// is returned as-is and the deployment's asset allowlist decides whether
+	// it is accepted.
+	return hash, true
+}
+
+// GetAssetDecimals resolves the decimals of an asset symbol or contract hash.
+func GetAssetDecimals(network, asset string) (uint8, bool) {
+	info := GetNetworkInfo(network)
+	if info == nil {
+		return 0, false
+	}
+	normalized := NormalizeAsset(asset)
+	for symbol, decimals := range info.AssetDecimals {
+		if NormalizeAsset(symbol) == normalized {
+			return decimals, true
+		}
+	}
+	hash := NormalizeContractHash(asset)
+	if hash == "" {
+		return 0, false
+	}
+	for symbol, contract := range info.AssetContracts {
+		if NormalizeContractHash(contract) == hash {
+			decimals, ok := info.AssetDecimals[symbol]
+			return decimals, ok
+		}
+	}
+	return 0, false
+}
+
+var networkInfo = map[string]NetworkInfo{
+	NetworkMainnet: {
+		Network:        NetworkMainnet,
+		NetworkName:    "Casper Mainnet",
+		NetworkID:      "casper",
+		DefaultURLs:    []string{DefaultFacilitatorURL},
+		AssetContracts: map[string]string{},
+		AssetDecimals:  map[string]uint8{WCSPRSymbol: MoteDecimals},
+	},
+	NetworkTestnet: {
+		Network:        NetworkTestnet,
+		NetworkName:    "Casper Testnet",
+		NetworkID:      "casper-test",
+		DefaultURLs:    []string{DefaultFacilitatorURL},
+		AssetContracts: map[string]string{},
+		AssetDecimals:  map[string]uint8{WCSPRSymbol: MoteDecimals},
+	},
+}

--- a/scheme/casper/chaincfg_test.go
+++ b/scheme/casper/chaincfg_test.go
@@ -1,0 +1,157 @@
+package casper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetNetworkInfoIncludesDefaultFacilitatorEndpoints(t *testing.T) {
+	tests := []struct {
+		network     string
+		networkName string
+		networkID   string
+		defaultURL  string
+	}{
+		{NetworkMainnet, "Casper Mainnet", "casper", DefaultFacilitatorURL},
+		{NetworkTestnet, "Casper Testnet", "casper-test", DefaultFacilitatorURL},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.network, func(t *testing.T) {
+			info := GetNetworkInfo(tt.network)
+			require.NotNil(t, info)
+			require.Equal(t, tt.network, info.Network)
+			require.Equal(t, tt.networkName, info.NetworkName)
+			require.Equal(t, tt.networkID, info.NetworkID)
+			require.NotEmpty(t, info.DefaultURLs)
+			require.Equal(t, tt.defaultURL, info.DefaultURLs[0])
+			require.Equal(t, tt.networkName, GetNetworkName(tt.network))
+			require.Equal(t, tt.networkID, GetNetworkID(tt.network))
+			require.Equal(t, info.DefaultURLs, GetDefaultURLs(tt.network))
+		})
+	}
+
+	require.Nil(t, GetNetworkInfo("casper:unknown"))
+	require.Empty(t, GetNetworkName("casper:unknown"))
+	require.Empty(t, GetNetworkID("casper:unknown"))
+	require.Nil(t, GetDefaultURLs("casper:unknown"))
+}
+
+func TestIsCasperNetwork(t *testing.T) {
+	tests := []struct {
+		network string
+		want    bool
+	}{
+		{NetworkMainnet, true},
+		{NetworkTestnet, true},
+		{"casper:unknown", true},
+		{" casper:casper", true},
+		{"eip155:8453", false},
+		{"sui:mainnet", false},
+		{"solana:mainnet", false},
+		{"casper", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.network, func(t *testing.T) {
+			require.Equal(t, tt.want, IsCasperNetwork(tt.network))
+		})
+	}
+}
+
+func TestParseNetwork(t *testing.T) {
+	tests := []struct {
+		name          string
+		network       string
+		wantNamespace string
+		wantReference string
+		wantErr       bool
+	}{
+		{name: "mainnet", network: NetworkMainnet, wantNamespace: "casper", wantReference: "casper"},
+		{name: "testnet", network: NetworkTestnet, wantNamespace: "casper", wantReference: "casper-test"},
+		{name: "padded", network: "  casper:casper-test  ", wantNamespace: "casper", wantReference: "casper-test"},
+		{name: "unsupported reference", network: "casper:casper-dev", wantErr: true},
+		{name: "wrong namespace", network: "eip155:8453", wantErr: true},
+		{name: "missing reference", network: "casper:", wantErr: true},
+		{name: "not caip2", network: "casper", wantErr: true},
+		{name: "empty", network: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespace, reference, err := ParseNetwork(tt.network)
+			if tt.wantErr {
+				require.ErrorIs(t, err, ErrInvalidNetwork)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantNamespace, namespace)
+			require.Equal(t, tt.wantReference, reference)
+		})
+	}
+}
+
+func TestGetAssetContract(t *testing.T) {
+	const contract = "1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff001"
+
+	tests := []struct {
+		name    string
+		network string
+		asset   string
+		want    string
+		wantOK  bool
+	}{
+		{name: "bare contract hash", network: NetworkMainnet, asset: contract, want: contract, wantOK: true},
+		{name: "hash prefixed contract", network: NetworkTestnet, asset: "hash-" + contract, want: contract, wantOK: true},
+		{name: "unknown symbol", network: NetworkMainnet, asset: "NOT_A_TOKEN", wantOK: false},
+		{name: "malformed hash", network: NetworkMainnet, asset: "hash-1b2c", wantOK: false},
+		{name: "unsupported network", network: "casper:unknown", asset: contract, wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := GetAssetContract(tt.network, tt.asset)
+			require.Equal(t, tt.wantOK, ok)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetAssetDecimals(t *testing.T) {
+	decimals, ok := GetAssetDecimals(NetworkMainnet, WCSPRSymbol)
+	require.True(t, ok)
+	require.Equal(t, MoteDecimals, decimals)
+	require.Equal(t, uint8(9), decimals)
+
+	decimals, ok = GetAssetDecimals(NetworkTestnet, "wcspr")
+	require.True(t, ok)
+	require.Equal(t, MoteDecimals, decimals)
+
+	_, ok = GetAssetDecimals(NetworkMainnet, "NOT_A_TOKEN")
+	require.False(t, ok)
+
+	_, ok = GetAssetDecimals("casper:unknown", WCSPRSymbol)
+	require.False(t, ok)
+}
+
+func TestGetAssetTypesIsDeploymentConfigured(t *testing.T) {
+	// CEP-18 contract hashes are supplied per deployment, so no contract hash
+	// is hard-coded for either network.
+	require.Empty(t, GetAssetTypes(NetworkMainnet))
+	require.Empty(t, GetAssetTypes(NetworkTestnet))
+	require.Nil(t, GetAssetTypes("casper:unknown"))
+}
+
+func TestGetNetworkInfoReturnsCopy(t *testing.T) {
+	info := GetNetworkInfo(NetworkMainnet)
+	require.NotNil(t, info)
+	info.DefaultURLs[0] = "http://mutated.invalid"
+	info.AssetDecimals[WCSPRSymbol] = 0
+
+	fresh := GetNetworkInfo(NetworkMainnet)
+	require.NotNil(t, fresh)
+	require.Equal(t, DefaultFacilitatorURL, fresh.DefaultURLs[0])
+	require.Equal(t, MoteDecimals, fresh.AssetDecimals[WCSPRSymbol])
+}

--- a/scheme/casper/client.go
+++ b/scheme/casper/client.go
@@ -1,0 +1,220 @@
+package casper
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gosuda/x402-facilitator/types"
+	"github.com/gosuda/x402-facilitator/utils"
+)
+
+const (
+	// VerifyPath is the Casper facilitator verification endpoint.
+	VerifyPath = "/verify"
+	// SettlePath is the Casper facilitator settlement endpoint.
+	SettlePath = "/settle"
+	// SupportedPath is the Casper facilitator discovery endpoint.
+	SupportedPath = "/supported"
+
+	defaultRequestTimeout = 30 * time.Second
+	maxResponseBytes      = 4 << 20
+)
+
+// Client owns Casper facilitator endpoint failover and JSON transport. It
+// deliberately depends only on the standard library so that deployments do
+// not have to pull in a Casper SDK to settle payments.
+type Client struct {
+	mu         sync.RWMutex
+	url        string
+	endpoints  []string
+	httpClient *http.Client
+}
+
+// NewClientWithEndpoints builds a client that prefers url and falls back to
+// the supplied endpoints in order.
+func NewClientWithEndpoints(url string, endpoints []string) *Client {
+	candidates := utils.EndpointCandidates(append([]string{url}, endpoints...))
+	activeURL := ""
+	if len(candidates) > 0 {
+		activeURL = candidates[0]
+	}
+	return &Client{
+		url:        activeURL,
+		endpoints:  candidates,
+		httpClient: &http.Client{Timeout: defaultRequestTimeout},
+	}
+}
+
+// NewClientForNetwork builds a client for a supported Casper network.
+func NewClientForNetwork(network string, endpoints []string) (*Client, error) {
+	info := GetNetworkInfo(network)
+	if info == nil {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidNetwork, network)
+	}
+	candidates := utils.EndpointCandidates(append(append([]string(nil), endpoints...), info.DefaultURLs...))
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("no endpoints configured for %s", network)
+	}
+	return NewClientWithEndpoints("", candidates), nil
+}
+
+// ActiveEndpoint returns the endpoint that most recently served a request.
+func (c *Client) ActiveEndpoint() string {
+	if c == nil {
+		return ""
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.url
+}
+
+// Close releases idle connections held by the client.
+func (c *Client) Close() error {
+	if c == nil || c.httpClient == nil {
+		return nil
+	}
+	c.httpClient.CloseIdleConnections()
+	return nil
+}
+
+// Verify asks the Casper facilitator whether a payment payload satisfies the
+// supplied requirements.
+func (c *Client) Verify(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements) (*VerifyResponse, error) {
+	if payload == nil || req == nil {
+		return nil, ErrEmptyPayload
+	}
+	body := VerifyRequest{
+		X402Version:         int(types.X402VersionV2),
+		PaymentPayload:      *payload,
+		PaymentRequirements: *req,
+	}
+	var response VerifyResponse
+	if err := c.do(ctx, http.MethodPost, VerifyPath, body, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// Settle asks the Casper facilitator to broadcast and settle a payment.
+func (c *Client) Settle(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements) (*SettleResponse, error) {
+	if payload == nil || req == nil {
+		return nil, ErrEmptyPayload
+	}
+	body := SettleRequest{
+		X402Version:         int(types.X402VersionV2),
+		PaymentPayload:      *payload,
+		PaymentRequirements: *req,
+	}
+	var response SettleResponse
+	if err := c.do(ctx, http.MethodPost, SettlePath, body, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// Supported returns the (scheme, network) pairs the facilitator accepts.
+func (c *Client) Supported(ctx context.Context) (*SupportedResponse, error) {
+	var response SupportedResponse
+	if err := c.do(ctx, http.MethodGet, SupportedPath, nil, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body interface{}, out interface{}) error {
+	if c == nil {
+		return ErrEmptyPayload
+	}
+	var encoded []byte
+	if body != nil {
+		var err error
+		if encoded, err = json.Marshal(body); err != nil {
+			return fmt.Errorf("encode request: %w", err)
+		}
+	}
+	return c.call(ctx, func(ctx context.Context, endpoint string) error {
+		return c.request(ctx, method, endpoint+path, encoded, out)
+	})
+}
+
+func (c *Client) request(ctx context.Context, method, url string, body []byte, out interface{}) error {
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+	request, err := http.NewRequestWithContext(ctx, method, url, reader)
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Accept", "application/json")
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+
+	httpClient := c.httpClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	response, err := httpClient.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	payload, err := io.ReadAll(io.LimitReader(response.Body, maxResponseBytes))
+	if err != nil {
+		return err
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return fmt.Errorf("casper facilitator %s: %s", response.Status, errorMessage(payload))
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(payload, out); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) call(ctx context.Context, action utils.EndpointOperation) error {
+	c.mu.RLock()
+	candidates := append([]string(nil), c.endpoints...)
+	active := c.url
+	c.mu.RUnlock()
+
+	if active != "" {
+		candidates = utils.EndpointCandidates(append([]string{active}, candidates...))
+	}
+	endpoint, err := utils.DoWithEndpoint(ctx, candidates, action)
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.url = endpoint
+	c.mu.Unlock()
+	return nil
+}
+
+func errorMessage(payload []byte) string {
+	var response ErrorResponse
+	if err := json.Unmarshal(payload, &response); err == nil {
+		if message := strings.TrimSpace(response.Message); message != "" {
+			return message
+		}
+		if message := strings.TrimSpace(response.Error); message != "" {
+			return message
+		}
+	}
+	if message := strings.TrimSpace(string(payload)); message != "" {
+		return message
+	}
+	return "empty response body"
+}

--- a/scheme/casper/client_test.go
+++ b/scheme/casper/client_test.go
@@ -1,0 +1,256 @@
+package casper
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gosuda/x402-facilitator/types"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testPayer    = "account-hash-1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff000"
+	testPayTo    = "account-hash-aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+	testContract = "1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff001"
+)
+
+func testPaymentPayload() *types.PaymentPayload {
+	return &types.PaymentPayload{
+		X402Version: int(types.X402VersionV2),
+		Payload: map[string]interface{}{
+			"signature": "01aabb",
+			"payer":     testPayer,
+			"deploy":    map[string]interface{}{"hash": "aabb"},
+		},
+		Accepted: *testPaymentRequirements(),
+	}
+}
+
+func testPaymentRequirements() *types.PaymentRequirements {
+	return &types.PaymentRequirements{
+		Scheme:            string(types.Exact),
+		Network:           NetworkTestnet,
+		Asset:             testContract,
+		Amount:            "1000000000",
+		PayTo:             testPayTo,
+		MaxTimeoutSeconds: 60,
+	}
+}
+
+func TestClientVerify(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		body       string
+		wantValid  bool
+		wantReason string
+		wantErr    bool
+	}{
+		{
+			name:      "valid payment",
+			status:    http.StatusOK,
+			body:      `{"isValid":true,"payer":"` + testPayer + `"}`,
+			wantValid: true,
+		},
+		{
+			name:       "invalid payment",
+			status:     http.StatusOK,
+			body:       `{"isValid":false,"invalidReason":"insufficient_balance","invalidMessage":"payer balance too low"}`,
+			wantValid:  false,
+			wantReason: "insufficient_balance",
+		},
+		{
+			name:    "server error",
+			status:  http.StatusInternalServerError,
+			body:    `{"error":"boom"}`,
+			wantErr: true,
+		},
+		{
+			name:    "malformed body",
+			status:  http.StatusOK,
+			body:    `not json`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotRequest VerifyRequest
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodPost, r.Method)
+				require.Equal(t, VerifyPath, r.URL.Path)
+				require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&gotRequest))
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			client := NewClientWithEndpoints(server.URL, nil)
+			defer client.Close()
+
+			response, err := client.Verify(context.Background(), testPaymentPayload(), testPaymentRequirements())
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Nil(t, response)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantValid, response.IsValid)
+			require.Equal(t, tt.wantReason, response.InvalidReason)
+
+			require.Equal(t, int(types.X402VersionV2), gotRequest.X402Version)
+			require.Equal(t, NetworkTestnet, gotRequest.PaymentRequirements.Network)
+			require.Equal(t, "1000000000", gotRequest.PaymentRequirements.Amount)
+			require.Equal(t, testContract, gotRequest.PaymentRequirements.Asset)
+			require.Equal(t, string(types.Exact), gotRequest.PaymentPayload.Accepted.Scheme)
+		})
+	}
+}
+
+func TestClientSettle(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      int
+		body        string
+		wantSuccess bool
+		wantTx      string
+		wantErr     bool
+	}{
+		{
+			name:        "settled",
+			status:      http.StatusOK,
+			body:        `{"success":true,"transaction":"deadbeef","network":"` + NetworkTestnet + `","payer":"` + testPayer + `"}`,
+			wantSuccess: true,
+			wantTx:      "deadbeef",
+		},
+		{
+			name:        "settlement failed",
+			status:      http.StatusOK,
+			body:        `{"success":false,"errorReason":"transaction_failed","errorMessage":"deploy reverted"}`,
+			wantSuccess: false,
+		},
+		{
+			name:    "bad gateway",
+			status:  http.StatusBadGateway,
+			body:    `{"message":"upstream unavailable"}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodPost, r.Method)
+				require.Equal(t, SettlePath, r.URL.Path)
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			client := NewClientWithEndpoints(server.URL, nil)
+			defer client.Close()
+
+			response, err := client.Settle(context.Background(), testPaymentPayload(), testPaymentRequirements())
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "upstream unavailable")
+				require.Nil(t, response)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantSuccess, response.Success)
+			require.Equal(t, tt.wantTx, response.Transaction)
+		})
+	}
+}
+
+func TestClientSupported(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, SupportedPath, r.URL.Path)
+		_, _ = w.Write([]byte(`{"kinds":[
+			{"x402Version":2,"scheme":"exact","network":"casper:casper"},
+			{"x402Version":2,"scheme":"exact","network":"casper:casper-test","extra":{"asset":"WCSPR"}}
+		]}`))
+	}))
+	defer server.Close()
+
+	client := NewClientWithEndpoints(server.URL, nil)
+	defer client.Close()
+
+	response, err := client.Supported(context.Background())
+	require.NoError(t, err)
+	require.Len(t, response.Kinds, 2)
+	require.Equal(t, NetworkMainnet, response.Kinds[0].Network)
+	require.Equal(t, string(types.Exact), response.Kinds[0].Scheme)
+	require.Equal(t, int(types.X402VersionV2), response.Kinds[0].X402Version)
+	require.Equal(t, NetworkTestnet, response.Kinds[1].Network)
+	require.Equal(t, "WCSPR", response.Kinds[1].Extra["asset"])
+}
+
+func TestClientFailsOverToNextEndpoint(t *testing.T) {
+	var healthyHits int
+	broken := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer broken.Close()
+	healthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		healthyHits++
+		_, _ = w.Write([]byte(`{"kinds":[{"x402Version":2,"scheme":"exact","network":"casper:casper"}]}`))
+	}))
+	defer healthy.Close()
+
+	client := NewClientWithEndpoints(broken.URL, []string{healthy.URL})
+	defer client.Close()
+
+	response, err := client.Supported(context.Background())
+	require.NoError(t, err)
+	require.Len(t, response.Kinds, 1)
+	require.Equal(t, 1, healthyHits)
+	require.Equal(t, healthy.URL, client.ActiveEndpoint())
+}
+
+func TestClientAllEndpointsFail(t *testing.T) {
+	broken := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer broken.Close()
+
+	client := NewClientWithEndpoints(broken.URL, nil)
+	defer client.Close()
+
+	_, err := client.Supported(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "all endpoints failed")
+}
+
+func TestNewClientForNetwork(t *testing.T) {
+	client, err := NewClientForNetwork(NetworkMainnet, nil)
+	require.NoError(t, err)
+	require.Equal(t, DefaultFacilitatorURL, client.ActiveEndpoint())
+	require.NoError(t, client.Close())
+
+	client, err = NewClientForNetwork(NetworkTestnet, []string{"https://casper.example.invalid"})
+	require.NoError(t, err)
+	require.Equal(t, "https://casper.example.invalid", client.ActiveEndpoint())
+	require.NoError(t, client.Close())
+
+	_, err = NewClientForNetwork("casper:unknown", nil)
+	require.ErrorIs(t, err, ErrInvalidNetwork)
+}
+
+func TestClientRejectsNilArguments(t *testing.T) {
+	client := NewClientWithEndpoints("https://casper.example.invalid", nil)
+	defer client.Close()
+
+	_, err := client.Verify(context.Background(), nil, testPaymentRequirements())
+	require.ErrorIs(t, err, ErrEmptyPayload)
+
+	_, err = client.Settle(context.Background(), testPaymentPayload(), nil)
+	require.ErrorIs(t, err, ErrEmptyPayload)
+}

--- a/scheme/casper/types.go
+++ b/scheme/casper/types.go
@@ -1,0 +1,56 @@
+package casper
+
+import "github.com/gosuda/x402-facilitator/types"
+
+// VerifyRequest is the body of POST /verify on the Casper facilitator. It
+// mirrors the x402 v2 wire format used by this repository.
+type VerifyRequest struct {
+	X402Version         int                       `json:"x402Version"`
+	PaymentPayload      types.PaymentPayload      `json:"paymentPayload"`
+	PaymentRequirements types.PaymentRequirements `json:"paymentRequirements"`
+}
+
+// VerifyResponse is the body returned by POST /verify.
+type VerifyResponse struct {
+	IsValid        bool   `json:"isValid"`
+	InvalidReason  string `json:"invalidReason,omitempty"`
+	InvalidMessage string `json:"invalidMessage,omitempty"`
+	Payer          string `json:"payer,omitempty"`
+}
+
+// SettleRequest is the body of POST /settle on the Casper facilitator.
+type SettleRequest struct {
+	X402Version         int                       `json:"x402Version"`
+	PaymentPayload      types.PaymentPayload      `json:"paymentPayload"`
+	PaymentRequirements types.PaymentRequirements `json:"paymentRequirements"`
+}
+
+// SettleResponse is the body returned by POST /settle.
+type SettleResponse struct {
+	Success      bool   `json:"success"`
+	ErrorReason  string `json:"errorReason,omitempty"`
+	ErrorMessage string `json:"errorMessage,omitempty"`
+	Payer        string `json:"payer,omitempty"`
+	Transaction  string `json:"transaction"`
+	Network      string `json:"network"`
+}
+
+// SupportedKind is one entry of the GET /supported response.
+type SupportedKind struct {
+	X402Version int                    `json:"x402Version"`
+	Scheme      string                 `json:"scheme"`
+	Network     string                 `json:"network"`
+	Extra       map[string]interface{} `json:"extra,omitempty"`
+}
+
+// SupportedResponse is the body returned by GET /supported.
+type SupportedResponse struct {
+	Kinds []SupportedKind `json:"kinds"`
+}
+
+// ErrorResponse is the error body returned by the Casper facilitator for
+// non-2xx responses.
+type ErrorResponse struct {
+	Error   string `json:"error,omitempty"`
+	Message string `json:"message,omitempty"`
+}


### PR DESCRIPTION
## Summary

This PR adds support for the Casper network family (`casper:casper` mainnet and `casper:casper-test` testnet) to the `exact` scheme, following the pluggable scheme x network architecture already in place.

The change is purely additive. No existing EVM, Sui, Solana, or Tron behaviour is modified; the only edits to existing files are the routing case in `facilitator/iface.go`, the README support matrix, and the `config.toml` comments.

## Architecture fit

The new code mirrors `scheme/sui` as the non-EVM reference implementation:

- `scheme/casper/casper.go` - scheme primitives, error taxonomy, payload parsing, address/contract-hash normalization, and mote amount conversion.
- `scheme/casper/chaincfg.go` - `NetworkInfo` registry and `GetNetworkInfo`/`GetNetworkName`/`GetNetworkID`/`GetDefaultURLs` accessors, matching the Sui accessor set, plus CAIP-2 parsing helpers.
- `scheme/casper/client.go` - endpoint failover through `utils.DoWithEndpoint` and JSON transport, same ownership split as `scheme/sui/client.go`.
- `scheme/casper/types.go` - x402 v2 wire types for the verify/settle/supported exchanges.
- `facilitator/casper.go` - implements the `Facilitator` interface with the same `Verify`/`Settle`/`Supported` shape and the same `validatePaymentEnvelope` envelope checks as `facilitator/sui.go`, reusing the existing `types.Err*` reason codes.

## Settlement mechanism

Casper payments in the `exact` scheme settle in wCSPR, a CEP-18 token with 9 decimals whose atomic unit is a mote. Amounts stay integer motes encoded as decimal strings, consistent with the rest of the facilitator.

Sub-mote precision is never silently discarded: `CSPRToMotes` returns an explicit `ErrSubMotePrecision` error rather than truncating, so a payment cannot be under-settled by a rounding bug.

Casper payments are authorized by the payer and broadcast by a Casper facilitator service, so this implementation delegates verification and settlement over HTTP (`POST /verify`, `POST /settle`, `GET /supported`) after performing all envelope, asset, recipient, and amount validation locally. Locally invalid payments never reach the network. The base URL defaults to `https://x402-facilitator.cspr.cloud` and is configurable through the existing `url` field in `config.toml` or the `CASPER_FACILITATOR_URL` environment variable.

No CEP-18 contract hash is hard-coded. Contract hashes are supplied per deployment through `CasperFacilitatorOptions.AssetContracts` or the payment requirements, and are validated for syntactic correctness.

## Dependencies

None added. The client is plain `net/http` plus `encoding/json`, so `go.mod` and `go.sum` are untouched.

## Test evidence

Added 50 table-driven test cases in the style of the existing Sui and EVM tests, with no network access; the facilitator backend is faked with `httptest.Server`.

- `scheme/casper/casper_test.go` - address and contract hash validation, mote parsing, CSPR/mote conversion including the sub-mote precision error and round trips, payload parsing and JSON round trip.
- `scheme/casper/chaincfg_test.go` - CAIP-2 network parsing and validation, network metadata, asset resolution, defensive copying of network info.
- `scheme/casper/client_test.go` - verify/settle/supported paths against `httptest.Server`, request wire format assertions, error bodies, endpoint failover.
- `facilitator/casper_test.go` - x402 v2 envelope construction and validation, malformed payload handling, remote delegation, settlement paths, and routing through `NewFacilitator`.

`go vet ./...` and `gofmt -l .` are clean. `go test ./...` output:

```
?   	github.com/gosuda/x402-facilitator/api	[no test files]
?   	github.com/gosuda/x402-facilitator/api/client	[no test files]
?   	github.com/gosuda/x402-facilitator/api/middleware	[no test files]
?   	github.com/gosuda/x402-facilitator/api/swagger	[no test files]
?   	github.com/gosuda/x402-facilitator/cmd/client	[no test files]
?   	github.com/gosuda/x402-facilitator/cmd/facilitator	[no test files]
--- FAIL: TestEVMVerify (0.13s)
--- FAIL: TestEVMSettle (0.10s)
FAIL
FAIL	github.com/gosuda/x402-facilitator/facilitator	1.085s
ok  	github.com/gosuda/x402-facilitator/internal/sdk	(cached)
ok  	github.com/gosuda/x402-facilitator/scheme/casper	(cached)
ok  	github.com/gosuda/x402-facilitator/scheme/evm	(cached)
?   	github.com/gosuda/x402-facilitator/scheme/evm/eip3009	[no test files]
?   	github.com/gosuda/x402-facilitator/scheme/evm/permit2	[no test files]
?   	github.com/gosuda/x402-facilitator/scheme/solana	[no test files]
ok  	github.com/gosuda/x402-facilitator/scheme/sui	(cached)
ok  	github.com/gosuda/x402-facilitator/scheme/sui/grpc	(cached)
?   	github.com/gosuda/x402-facilitator/scheme/tron	[no test files]
ok  	github.com/gosuda/x402-facilitator/types	(cached)
ok  	github.com/gosuda/x402-facilitator/utils	(cached)
FAIL
```

`TestEVMVerify` and `TestEVMSettle` fail identically on an unmodified `origin/main` checkout: both call `NewEVMFacilitator` with the empty `PrivateKey` constant in `facilitator/evm_test.go` and fail with `invalid private key length`. They are unrelated to this change, and we left them untouched. All Casper tests pass.

## Maintenance

We are happy to maintain this module going forward, including keeping the network registry current and responding to issues on the Casper integration. Please let us know if you would prefer a different layout for any part of this, or if you would like the asset allowlist wired into `cmd/facilitator/config.go` as a first-class configuration field in this PR rather than a follow-up.
